### PR TITLE
feat: add python support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -325,6 +325,7 @@ dependencies = [
  "deno_core",
  "deno_error",
  "deno_unsync",
+ "pyo3",
  "scopeguard",
  "thiserror",
  "tokio",
@@ -686,6 +687,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
+
+[[package]]
 name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -749,6 +756,15 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "minimal-lexical"
@@ -913,6 +929,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "portable-atomic"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+
+[[package]]
 name = "prettyplease"
 version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -952,6 +974,68 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "pyo3"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8970a78afe0628a3e3430376fc5fd76b6b45c4d43360ffd6cdd40bdde72b682a"
+dependencies = [
+ "indoc",
+ "libc",
+ "memoffset",
+ "once_cell",
+ "portable-atomic",
+ "pyo3-build-config",
+ "pyo3-ffi",
+ "pyo3-macros",
+ "unindent",
+]
+
+[[package]]
+name = "pyo3-build-config"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "458eb0c55e7ece017adeba38f2248ff3ac615e53660d7c71a238d7d2a01c7598"
+dependencies = [
+ "once_cell",
+ "target-lexicon",
+]
+
+[[package]]
+name = "pyo3-ffi"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7114fe5457c61b276ab77c5055f206295b812608083644a5c5b2640c3102565c"
+dependencies = [
+ "libc",
+ "pyo3-build-config",
+]
+
+[[package]]
+name = "pyo3-macros"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8725c0a622b374d6cb051d11a0983786448f7785336139c3c94f5aa6bef7e50"
+dependencies = [
+ "proc-macro2",
+ "pyo3-macros-backend",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pyo3-macros-backend"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4109984c22491085343c05b0dbc54ddc405c3cf7b4374fc533f5c3313a572ccc"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "pyo3-build-config",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1285,6 +1369,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
+name = "target-lexicon"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e502f78cdbb8ba4718f566c418c52bc729126ffd16baee5baa718cf25dd5a69a"
+
+[[package]]
 name = "thiserror"
 version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1354,6 +1444,12 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "unindent"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "url"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,5 @@ deno_unsync = "0.4.2"
 scopeguard = "1.2.0"
 thiserror = "2.0.12"
 tokio = { version = "1.44.2", features = ["full"] }
+pyo3 = {version = "0.25.1", features = ["auto-initialize"] }
+

--- a/examples/js/hello.js
+++ b/examples/js/hello.js
@@ -1,3 +1,2 @@
-console.log("user Js", "Hello World, from JS");
-
-Runtime.serve();
+const result = Runtime.double(4);
+console.log("user Js", "Hello World, from JS", result);

--- a/examples/py/hello.py
+++ b/examples/py/hello.py
@@ -1,0 +1,1 @@
+print("hello world from python")

--- a/examples/py/hello.py
+++ b/examples/py/hello.py
@@ -1,1 +1,6 @@
+from runtime import double
+
+result = double(2)
+print(result)
+
 print("hello world from python")

--- a/examples/py/hello.py
+++ b/examples/py/hello.py
@@ -3,4 +3,6 @@ from runtime import double
 result = double(2)
 print(result)
 
+print(greet("Kalleby"))
+
 print("hello world from python")

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use std::env;
 
-use deno_server::runtime::executor::execute_js;
+use deno_server::runtime::executor::execute;
 
 fn main() {
     let args = &env::args().collect::<Vec<String>>()[1..];
@@ -15,7 +15,7 @@ fn main() {
         .build()
         .unwrap();
 
-    if let Err(error) = runtime.block_on(execute_js(file_path)) {
+    if let Err(error) = runtime.block_on(execute(file_path)) {
         eprintln!("error: {}", error);
     }
 }

--- a/src/runtime/js/bootstrap.js
+++ b/src/runtime/js/bootstrap.js
@@ -14,6 +14,7 @@ globalThis.bootstrap = {
 
 const runtimeNs = {
   serve: http.Http.serve,
+  double: ops.double_js,
 };
 
 function mainRuntimeBootstrap() {

--- a/src/runtime/py/bootstrap.py
+++ b/src/runtime/py/bootstrap.py
@@ -1,0 +1,5 @@
+print("[Bootstrap] Setting up Python environment")
+
+
+def greet(name):
+    return f"Hello, {name}!"


### PR DESCRIPTION
This PR adds python support for *cafe_runtime*. 
It allows a hybrid runtime that can run both Javascript and Python based on the entrypoint file extension.